### PR TITLE
Set up CI and update cabal file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,49 @@
+name: Tests
+
+# Trigger the workflow on push or pull request, but only for the main branch
+on:
+  pull_request:
+  push:
+    branches: ["master"]
+
+jobs:
+  generate-matrix:
+    name: "Generate matrix from cabal"
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract the tested GHC versions
+        id: set-matrix
+        uses: kleidukos/get-tested@v0.1.7.1
+        with:
+          cabal-file: hsqml.cabal
+          ubuntu-version: latest
+          version: 0.1.7.1
+  tests:
+    name: ${{ matrix.ghc }} on ${{ matrix.os }}
+    needs: generate-matrix
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
+    steps:
+      - name: Checkout base repo
+        uses: actions/checkout@v4
+      - name: Set up Haskell
+        id: setup-haskell
+        uses: haskell-actions/setup@v2
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: 'latest'
+      - name: Configure
+        run: cabal configure --enable-tests
+      - name: Cache
+        uses: actions/cache@v4.0.2
+        with:
+          path: ${{ steps.setup-haskell.outputs.cabal-store }}
+          key: ${{ runner.os }}-ghc-${{ matrix.ghc }}-cabal-${{ hashFiles('**/plan.json') }}
+          restore-keys: ${{ runner.os }}-ghc-${{ matrix.ghc }}-
+      - name: Build
+        run: cabal build all
+      - name: Test
+        run: make test

--- a/Setup.hs
+++ b/Setup.hs
@@ -12,6 +12,7 @@ import Distribution.PackageDescription
 import Distribution.Simple
 import Distribution.Simple.BuildPaths
 import Distribution.Simple.Compiler
+import Distribution.Simple.PreProcess.Types (Suffix(..))
 import Distribution.Simple.LocalBuildInfo
 import Distribution.Simple.Program
 import Distribution.Simple.Program.Ld
@@ -181,7 +182,7 @@ buildGHCiFix verb pkgDesc lbi lib =
         hsObjs = map ((bDir </>) . (<.> "o")) ms
         lname  = getHSLibraryName $ componentUnitId clbi
     stubObjs <- fmap catMaybes $
-      mapM (findFileWithExtension ["o"] [bDir]) $ map (++ "_stub") ms
+      mapM (findFileWithExtension [Suffix "o"] [bDir]) $ map (++ "_stub") ms
     (ld,_) <- requireProgram verb ldProgram (withPrograms lbi)
     combineObjectFiles verb lbi ld (bDir </> lname <.> "o") (stubObjs ++ hsObjs)
     (ghc,_) <- requireProgram verb ghcProgram (withPrograms lbi)

--- a/hsqml.cabal
+++ b/hsqml.cabal
@@ -1,63 +1,65 @@
 cabal-version:      3.8
-Name:               hsqml
-Version:            0.3.6.0
-Build-type:         Custom
-License:            BSD-3-Clause
-License-file:       LICENSE
-Copyright:          (c) 2010-2018 Robin KAY
-Author:             Robin KAY
-Maintainer:         komadori@gekkou.co.uk
-Stability:          experimental
-Homepage:           http://www.gekkou.co.uk/software/hsqml/
-Category:           Graphics, GUI
-Synopsis:           Haskell binding for Qt Quick
+name:               hsqml
+version:            0.3.6.0
+build-type:         Custom
+license:            BSD-3-Clause
+license-file:       LICENSE
+copyright:          (c) 2010-2018 Robin KAY
+author:             Robin KAY
+maintainer:         komadori@gekkou.co.uk
+stability:          experimental
+homepage:           http://www.gekkou.co.uk/software/hsqml/
+category:           Graphics, GUI
+synopsis:           Haskell binding for Qt Quick
+tested-with:        GHC ==9.4.8 || ==9.6.6 || ==9.8.2
+extra-source-files:
+  cbits/*.cpp
+  cbits/*.h
+  CHANGELOG
+  README
+  test/Graphics/QML/Test/*.hs
 
-tested-with: GHC ==9.4.8 || ==9.6.6 || ==9.8.2
+description:
+  A Haskell binding for Qt Quick, a cross-platform framework for creating
+  graphical user interfaces. For further information on installing and using
+  this library, please see the project's web site.
 
-Extra-source-files:
-    README CHANGELOG
-    cbits/*.cpp cbits/*.h test/Graphics/QML/Test/*.hs
+source-repository head
+  type:     git
+  location: https://github.com/prolic/HsQML
 
-Description:
-    A Haskell binding for Qt Quick, a cross-platform framework for creating
-    graphical user interfaces. For further information on installing and using
-    this library, please see the project's web site.
+flag UsePkgConfig
+  description:
+    Use pkg-config for libraries instead of the platform default mechanism.
 
-Source-repository head
-    type:     git
-    location: https://github.com/prolic/HsQML
+  default:     False
 
-Flag UsePkgConfig
-    Description:
-        Use pkg-config for libraries instead of the platform default mechanism.
-    Default: False
+flag ThreadedTestSuite
+  description: Build test executable with the threaded RTS.
+  default:     True
 
-Flag ThreadedTestSuite
-    Description:
-        Build test executable with the threaded RTS.
-    Default: True
+flag ForceGHCiLib
+  description:
+    Force enable GHCi workaround library if not using shared libraries.
 
-Flag ForceGHCiLib
-    Description:
-        Force enable GHCi workaround library if not using shared libraries.
-    Default: True
+  default:     True
 
-Flag UseExitHook
-    Description:
-        Override the OnExitHook symbol to shutdown the Qt framework on exit.
-    Default: True
+flag UseExitHook
+  description:
+    Override the OnExitHook symbol to shutdown the Qt framework on exit.
 
-Flag EnableQmlDebugging
-    Description:
-        Allow the QML debug server to be enabled via Qt arguments.
-    Default: False
+  default:     True
 
-Custom-Setup
-    Setup-depends:
-        base             == 4.*,
-        template-haskell == 2.*,
-        Cabal            >= 3.12 && < 4.0,
-        filepath         >= 1.3 && < 1.6
+flag EnableQmlDebugging
+  description: Allow the QML debug server to be enabled via Qt arguments.
+  default:     False
+
+custom-setup
+  setup-depends:
+    , base              >=4    && <5
+    , Cabal             >=3.12 && <4.0
+    , filepath          >=1.3  && <1.6
+    , template-haskell  >=2    && <3
 
 common extensions
   default-extensions:
@@ -73,112 +75,132 @@ common ghc-options
     -fhide-source-paths -Wno-unused-do-bind -fshow-hole-constraints
     -Wno-unticked-promoted-constructors
 
-Library
-    import: extensions
-    import: ghc-options
-    Build-depends:
-        base         == 4.*,
-        bytestring,
-        containers   >= 0.4 && < 0.8,
-        filepath     >= 1.3 && < 1.6,
-        text         >= 2.0 && < 2.2,
-        tagged       >= 0.4 && < 0.9,
-        transformers >= 0.2 && < 0.7
-    Exposed-modules:
-        Graphics.QML
-        Graphics.QML.Debug
-        Graphics.QML.Canvas
-        Graphics.QML.Engine
-        Graphics.QML.Marshal
-        Graphics.QML.Model
-        Graphics.QML.Objects
-        Graphics.QML.Objects.ParamNames
-        Graphics.QML.Objects.Weak
-    Other-modules:
-        Graphics.QML.Internal.BindPrim
-        Graphics.QML.Internal.BindCanvas
-        Graphics.QML.Internal.BindObj
-        Graphics.QML.Internal.BindCore
-        Graphics.QML.Internal.JobQueue
-        Graphics.QML.Internal.Marshal
-        Graphics.QML.Internal.MetaObj
-        Graphics.QML.Internal.Objects
-        Graphics.QML.Internal.Types
-    Hs-source-dirs: src
-    Cxx-sources:
-        cbits/Canvas.cpp
-        cbits/Class.cpp
-        cbits/Engine.cpp
-        cbits/Intrinsics.cpp
-        cbits/Manager.cpp
-        cbits/Model.cpp
-        cbits/Object.cpp
-    Include-dirs: cbits
-    X-moc-headers:
-        cbits/Canvas.h
-        cbits/Engine.h
-        cbits/Manager.h
-        cbits/Model.h
-    CC-options: --std=c++11
-    X-separate-cbits: True
-    build-tool-depends: c2hs:c2hs
-    if flag(ForceGHCiLib)
-        X-force-ghci-lib: True
-    if flag(UseExitHook)
-        CC-options: -DHSQML_USE_EXIT_HOOK
-    if flag(EnableQmlDebugging)
-        CC-options: -DQT_QML_DEBUG_NO_WARNING
-    if os(windows) && !flag(UsePkgConfig)
-        Include-dirs: /QT_ROOT/include
-        Extra-libraries:
-            Qt5Core, Qt5Gui, Qt5Widgets, Qt5Qml, Qt5Quick, stdc++
-        Extra-lib-dirs: /SYS_ROOT/bin /QT_ROOT/bin
-        if impl(ghc < 7.8)
-            -- Pre-7.8 GHCi can't load eh_frame sections
-            GHC-options: -optc-fno-asynchronous-unwind-tables
-    else
-        if os(darwin) && !flag(UsePkgConfig)
-            Frameworks: QtCore QtGui QtWidgets QtQml QtQuick
-            CC-options: -F /QT_ROOT/lib
-            GHC-options: -hide-option-framework-path /QT_ROOT/lib
-            GHC-shared-options: -hide-option-framework-path /QT_ROOT/lib
-            X-framework-dirs: /QT_ROOT/lib
-        else
-            Pkgconfig-depends:
-                Qt5Core    >= 5.0 && < 6.0,
-                Qt5Gui     >= 5.0 && < 6.0,
-                Qt5Widgets >= 5.0 && < 6.0,
-                Qt5Qml     >= 5.0 && < 6.0,
-                Qt5Quick   >= 5.0 && < 6.0
-        Extra-libraries: stdc++
+library
+  import:             extensions
+  import:             ghc-options
+  build-depends:
+    , base          >=4   && <5
+    , bytestring
+    , containers    >=0.4 && <0.8
+    , filepath      >=1.3 && <1.6
+    , tagged        >=0.4 && <0.9
+    , text          >=2.0 && <2.2
+    , transformers  >=0.2 && <0.7
 
-Test-Suite hsqml-test1
-    import: extensions
-    import: ghc-options
-    Type: exitcode-stdio-1.0
-    Hs-source-dirs: test
-    Main-is: Test1.hs
-    Build-depends:
-        base       == 4.*,
-        containers,
-        directory,
-        text,
-        tagged,
-        QuickCheck >= 2.4 && < 2.16,
-        hsqml
-    Other-modules:
-        Graphics.QML.Test.AutoListTest
-        Graphics.QML.Test.DataTest
-        Graphics.QML.Test.Framework
-        Graphics.QML.Test.Harness
-        Graphics.QML.Test.MayGen
-        Graphics.QML.Test.MixedTest
-        Graphics.QML.Test.ScriptDSL
-        Graphics.QML.Test.SignalTest
-        Graphics.QML.Test.SimpleTest
-        Graphics.QML.Test.TestObject
-    if os(darwin) && !flag(UsePkgConfig)
-        -- Library not registered yet
-        GHC-options: -hide-option-framework-path /QT_ROOT/lib
-    if flag(ThreadedTestSuite)
-        GHC-options: -threaded
+  exposed-modules:
+    Graphics.QML
+    Graphics.QML.Canvas
+    Graphics.QML.Debug
+    Graphics.QML.Engine
+    Graphics.QML.Marshal
+    Graphics.QML.Model
+    Graphics.QML.Objects
+    Graphics.QML.Objects.ParamNames
+    Graphics.QML.Objects.Weak
+
+  other-modules:
+    Graphics.QML.Internal.BindCanvas
+    Graphics.QML.Internal.BindCore
+    Graphics.QML.Internal.BindObj
+    Graphics.QML.Internal.BindPrim
+    Graphics.QML.Internal.JobQueue
+    Graphics.QML.Internal.Marshal
+    Graphics.QML.Internal.MetaObj
+    Graphics.QML.Internal.Objects
+    Graphics.QML.Internal.Types
+
+  hs-source-dirs:     src
+  cxx-sources:
+    cbits/Canvas.cpp
+    cbits/Class.cpp
+    cbits/Engine.cpp
+    cbits/Intrinsics.cpp
+    cbits/Manager.cpp
+    cbits/Model.cpp
+    cbits/Object.cpp
+
+  include-dirs:       cbits
+  x-moc-headers:
+    cbits/Canvas.h
+    cbits/Engine.h
+    cbits/Manager.h
+    cbits/Model.h
+
+  cc-options:         "--std=c++11"
+  x-separate-cbits:   True
+  build-tool-depends: c2hs:c2hs
+
+  if flag(forceghcilib)
+    x-force-ghci-lib: True
+
+  if flag(useexithook)
+    cc-options: -DHSQML_USE_EXIT_HOOK
+
+  if flag(enableqmldebugging)
+    cc-options: -DQT_QML_DEBUG_NO_WARNING
+
+  if (os(windows) && !flag(usepkgconfig))
+    include-dirs:    /QT_ROOT/include
+    extra-libraries:
+      Qt5Core
+      Qt5Gui
+      Qt5Widgets
+      Qt5Qml
+      Qt5Quick
+      stdc++
+
+    extra-lib-dirs:  /SYS_ROOT/bin /QT_ROOT/bin
+
+    if impl(ghc <7.8)
+      -- Pre-7.8 GHCi can't load eh_frame sections
+      ghc-options: -optc-fno-asynchronous-unwind-tables
+
+  else
+    if (os(osx) && !flag(usepkgconfig))
+      frameworks:         QtCore QtGui QtWidgets QtQml QtQuick
+      cc-options:         -F /QT_ROOT/lib
+      ghc-options:        -hide-option-framework-path /QT_ROOT/lib
+      ghc-shared-options: -hide-option-framework-path /QT_ROOT/lib
+      x-framework-dirs:   /QT_ROOT/lib
+
+    else
+      pkgconfig-depends:
+        Qt5Core >=5.0 && <6.0, Qt5Gui >=5.0 && <6.0,
+        Qt5Widgets >=5.0 && <6.0, Qt5Qml >=5.0 && <6.0,
+        Qt5Quick >=5.0 && <6.0
+
+    extra-libraries: stdc++
+
+test-suite hsqml-test1
+  import:         extensions
+  import:         ghc-options
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test
+  main-is:        Test1.hs
+  build-depends:
+    , base        >=4   && <5
+    , containers
+    , directory
+    , hsqml
+    , QuickCheck  >=2.4 && <2.16
+    , tagged
+    , text
+
+  other-modules:
+    Graphics.QML.Test.AutoListTest
+    Graphics.QML.Test.DataTest
+    Graphics.QML.Test.Framework
+    Graphics.QML.Test.Harness
+    Graphics.QML.Test.MayGen
+    Graphics.QML.Test.MixedTest
+    Graphics.QML.Test.ScriptDSL
+    Graphics.QML.Test.SignalTest
+    Graphics.QML.Test.SimpleTest
+    Graphics.QML.Test.TestObject
+
+  if (os(osx) && !flag(usepkgconfig))
+    -- Library not registered yet
+    ghc-options: -hide-option-framework-path /QT_ROOT/lib
+
+  if flag(threadedtestsuite)
+    ghc-options: -threaded

--- a/hsqml.cabal
+++ b/hsqml.cabal
@@ -11,13 +11,21 @@ Stability:          experimental
 Homepage:           http://www.gekkou.co.uk/software/hsqml/
 Category:           Graphics, GUI
 Synopsis:           Haskell binding for Qt Quick
+
+tested-with: GHC ==9.4.8 || ==9.6.6 || ==9.8.2
+
 Extra-source-files:
     README CHANGELOG
     cbits/*.cpp cbits/*.h test/Graphics/QML/Test/*.hs
+
 Description:
     A Haskell binding for Qt Quick, a cross-platform framework for creating
     graphical user interfaces. For further information on installing and using
     this library, please see the project's web site.
+
+Source-repository head
+    type:     git
+    location: https://github.com/prolic/HsQML
 
 Flag UsePkgConfig
     Description:
@@ -48,17 +56,32 @@ Custom-Setup
     Setup-depends:
         base             == 4.*,
         template-haskell == 2.*,
-        Cabal            >= 3.0 && < 4.0,
+        Cabal            >= 3.12 && < 4.0,
         filepath         >= 1.3 && < 1.6
 
+common extensions
+  default-extensions:
+    NoPolyKinds
+    TypeOperators
+
+  default-language:   GHC2021
+
+common ghc-options
+  ghc-options:
+    -Wall -Wcompat -Widentities -Wincomplete-record-updates
+    -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints
+    -fhide-source-paths -Wno-unused-do-bind -fshow-hole-constraints
+    -Wno-unticked-promoted-constructors
+
 Library
-    Default-language: Haskell2010
+    import: extensions
+    import: ghc-options
     Build-depends:
         base         == 4.*,
         bytestring,
-        containers   >= 0.4 && < 0.7,
+        containers   >= 0.4 && < 0.8,
         filepath     >= 1.3 && < 1.6,
-        text         >= 2.0 && < 2.1,
+        text         >= 2.0 && < 2.2,
         tagged       >= 0.4 && < 0.9,
         transformers >= 0.2 && < 0.7
     Exposed-modules:
@@ -82,7 +105,7 @@ Library
         Graphics.QML.Internal.Objects
         Graphics.QML.Internal.Types
     Hs-source-dirs: src
-    C-sources:
+    Cxx-sources:
         cbits/Canvas.cpp
         cbits/Class.cpp
         cbits/Engine.cpp
@@ -130,17 +153,18 @@ Library
         Extra-libraries: stdc++
 
 Test-Suite hsqml-test1
+    import: extensions
+    import: ghc-options
     Type: exitcode-stdio-1.0
-    Default-language: Haskell2010
     Hs-source-dirs: test
     Main-is: Test1.hs
     Build-depends:
         base       == 4.*,
-        containers >= 0.4 && < 0.7,
-        directory  >= 1.1 && < 1.4,
-        text       >= 2.0 && < 2.1,
-        tagged     >= 0.4 && < 0.9,
-        QuickCheck >= 2.4 && < 2.14,
+        containers,
+        directory,
+        text,
+        tagged,
+        QuickCheck >= 2.4 && < 2.16,
         hsqml
     Other-modules:
         Graphics.QML.Test.AutoListTest
@@ -158,7 +182,3 @@ Test-Suite hsqml-test1
         GHC-options: -hide-option-framework-path /QT_ROOT/lib
     if flag(ThreadedTestSuite)
         GHC-options: -threaded
-
-Source-repository head
-    type:     darcs
-    location: http://hub.darcs.net/komadori/HsQML/

--- a/src/Graphics/QML/Marshal.hs
+++ b/src/Graphics/QML/Marshal.hs
@@ -3,6 +3,7 @@
     TypeFamilies,
     FlexibleInstances
   #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | Type classs and instances for marshalling values between Haskell and QML.
 module Graphics.QML.Marshal (
@@ -49,23 +50,17 @@ import Graphics.QML.Internal.Types
 
 import Control.Monad
 import Control.Monad.Trans.Maybe
-import Data.Bits (shiftL, (.|.))
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Unsafe as BSU
 import Data.Tagged
 import Data.Int
 import Data.Text (Text)
-import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TE
-import qualified Data.Text.Foreign as T
-import Data.Word (Word16)
 import Foreign.C.Types
 import Foreign.Marshal.Alloc
-import Foreign.Marshal.Array (pokeArray)
 import Foreign.Marshal.Utils (copyBytes)
 import Foreign.Ptr
 import Foreign.Storable
-import System.IO (hFlush, stdout)
 
 --
 -- Boolean built-in type


### PR DESCRIPTION
This PR brings the following changes:

* Declare the package as being tested with GHC 9.4, 9.6, and 9.8
* Enable `TypeOperators` as the code uses the type equality operator (`~`)
* Correct the location of the source code in the cabal file
* Enable more flags to help with code quality
* Require a recent version of the `Cabal` library

Bonus commits:

* eee1c93653a6d50ecbb24c30b981bf85b3422292 Removes redundant constraints from the API.
* bdf29a5b0666d9173fc903b442c91f457abd8133 Formats the cabal file with `cabal-fmt`

---

Closes #2 #3 