### PR TITLE
Add ClipboardHelper for clipboard operations

### DIFF
--- a/cbits/ClipboardHelper.cpp
+++ b/cbits/ClipboardHelper.cpp
@@ -1,0 +1,9 @@
+#include "ClipboardHelper.h"
+
+HsQMLClipboardHelper::HsQMLClipboardHelper(QObject *parent)
+    : QObject(parent) {}
+
+void HsQMLClipboardHelper::copyText(const QString &text) {
+    QClipboard *clipboard = QApplication::clipboard();
+    clipboard->setText(text);
+}

--- a/cbits/ClipboardHelper.h
+++ b/cbits/ClipboardHelper.h
@@ -1,0 +1,16 @@
+#ifndef CLIPBOARDHELPER_H
+#define CLIPBOARDHELPER_H
+
+#include <QApplication>
+#include <QClipboard>
+#include <QObject>
+
+class HsQMLClipboardHelper : public QObject {
+    Q_OBJECT
+public:
+    explicit HsQMLClipboardHelper(QObject *parent = nullptr);
+
+    Q_INVOKABLE void copyText(const QString &text);
+};
+
+#endif // CLIPBOARDHELPER_H

--- a/cbits/Manager.cpp
+++ b/cbits/Manager.cpp
@@ -10,6 +10,7 @@
 
 #include "Canvas.h"
 #include "Class.h"
+#include "ClipboardHelper.h"
 #include "Engine.h"
 #include "Manager.h"
 #include "Model.h"
@@ -430,6 +431,8 @@ HsQMLManagerApp::HsQMLManagerApp()
         "HsQML.Canvas", 1, 0, "OpenGLContextControl");
     qmlRegisterType<HsQMLAutoListModel>(
         "HsQML.Model", 1, 0, "AutoListModel");
+    qmlRegisterType<HsQMLClipboardHelper>(
+        "HsQML.Clipboard", 1, 0, "ClipboardHelper");
 }
 
 HsQMLManagerApp::~HsQMLManagerApp()

--- a/hsqml.cabal
+++ b/hsqml.cabal
@@ -85,6 +85,7 @@ Library
     C-sources:
         cbits/Canvas.cpp
         cbits/Class.cpp
+        cbits/ClipboardHelper.cpp
         cbits/Engine.cpp
         cbits/Intrinsics.cpp
         cbits/Manager.cpp
@@ -93,6 +94,7 @@ Library
     Include-dirs: cbits
     X-moc-headers:
         cbits/Canvas.h
+        cbits/ClipboardHelper.h
         cbits/Engine.h
         cbits/Manager.h
         cbits/Model.h


### PR DESCRIPTION
- Added ClipboardHelper.h and ClipboardHelper.cpp to implement clipboard functionality.
- Registered HsQMLClipboardHelper type in QML

This update allows QML to access clipboard operations through a C++ helper class, enabling text copying to the system clipboard.