### PR TITLE
Use C++ fields for C++ files

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -152,8 +152,8 @@ fixQtBuild verb lbi build = do
       createDirectoryIfMissingVerbose verb True (takeDirectory o)
       runProgram verb moc $ [i,"-o",o] ++ args) $ zip incs cpps
   -- Add the moc generated source files to be compiled
-  return build {cSources = cpps ++ cSources build,
-                ccOptions = "-fPIC" : ccOptions build}
+  return build {cxxSources = cpps ++ cxxSources build,
+                cxxOptions = "-fPIC" : cxxOptions build}
 
 needsGHCiFix :: PackageDescription -> LocalBuildInfo -> Bool
 needsGHCiFix pkgDesc lbi =
@@ -200,7 +200,7 @@ buildGHCiFix verb pkgDesc lbi lib =
       ["-shared","-o",bDir </> (mkGHCiFixLibName pkgDesc platform)] ++
       (ldOptions bi) ++ (map ("-l" ++) $ extraLibs bi) ++
       (map ("-L" ++) $ extraLibDirs bi) ++
-      (map ((bDir </>) . flip replaceExtension objExtension) $ cSources bi))
+      (map ((bDir </>) . flip replaceExtension objExtension) $ cxxSources bi))
     return ()
 
 mocProgram :: Program

--- a/hsqml.cabal
+++ b/hsqml.cabal
@@ -108,7 +108,7 @@ Library
         Graphics.QML.Internal.Objects
         Graphics.QML.Internal.Types
     Hs-source-dirs: src
-    C-sources:
+    Cxx-sources:
         cbits/Canvas.cpp
         cbits/Class.cpp
         cbits/ClipboardHelper.cpp


### PR DESCRIPTION
Fix

> Warning: The following files listed in the main library's c-sources do not
> have the expected '.c' extension
> HsQML/dist-newstyle/build/aarch64-osx/ghc-9.6.7/hsqml-0.3.6.1/build/cbits/moc_Canvas.cpp,
> HsQML/dist-newstyle/build/aarch64-osx/ghc-9.6.7/hsqml-0.3.6.1/build/cbits/moc_ClipboardHelper.cpp,
> HsQML/dist-newstyle/build/aarch64-osx/ghc-9.6.7/hsqml-0.3.6.1/build/cbits/moc_Engine.cpp,
> HsQML/dist-newstyle/build/aarch64-osx/ghc-9.6.7/hsqml-0.3.6.1/build/cbits/moc_HighDpiScaling.cpp,
> HsQML/dist-newstyle/build/aarch64-osx/ghc-9.6.7/hsqml-0.3.6.1/build/cbits/moc_Manager.cpp,
> HsQML/dist-newstyle/build/aarch64-osx/ghc-9.6.7/hsqml-0.3.6.1/build/cbits/moc_Model.cpp.
> C++ files should be in the 'cxx-sources' stanza.
> See
> https://cabal.readthedocs.io/en/3.10/cabal-package.html#pkg-field-cxx-sources
